### PR TITLE
feat: Add color property to distinguish agents

### DIFF
--- a/schovi/agents/brainstorm-executor/AGENT.md
+++ b/schovi/agents/brainstorm-executor/AGENT.md
@@ -1,5 +1,6 @@
 ---
 name: brainstorm-executor
+color: green
 allowed-tools: ["Read", "Task", "Grep", "Glob"]
 ---
 

--- a/schovi/agents/datadog-analyzer/AGENT.md
+++ b/schovi/agents/datadog-analyzer/AGENT.md
@@ -1,5 +1,6 @@
 ---
 name: datadog-analyzer
+color: orange
 allowed-tools:
   - "mcp__datadog-mcp__search_datadog_logs"
   - "mcp__datadog-mcp__search_datadog_metrics"

--- a/schovi/agents/debug-executor/AGENT.md
+++ b/schovi/agents/debug-executor/AGENT.md
@@ -1,5 +1,6 @@
 ---
 name: debug-executor
+color: red
 allowed-tools: ["Read", "Task", "Grep", "Glob"]
 ---
 

--- a/schovi/agents/gh-issue-analyzer/AGENT.md
+++ b/schovi/agents/gh-issue-analyzer/AGENT.md
@@ -2,6 +2,7 @@
 name: gh-issue-analyzer
 description: Fetches and summarizes GitHub issues via gh CLI without polluting parent context. Extracts issue metadata, comments, and labels into concise summaries.
 allowed-tools: ["Bash"]
+color: violet
 ---
 
 # GitHub Issue Analyzer Subagent

--- a/schovi/agents/gh-pr-analyzer/AGENT.md
+++ b/schovi/agents/gh-pr-analyzer/AGENT.md
@@ -2,6 +2,7 @@
 name: gh-pr-analyzer
 description: Fetches and summarizes GitHub pull requests via gh CLI with compact output. Extracts essential PR metadata optimized for analyze, debug, and plan commands.
 allowed-tools: ["Bash"]
+color: purple
 ---
 
 # GitHub PR Analyzer Subagent

--- a/schovi/agents/gh-pr-reviewer/AGENT.md
+++ b/schovi/agents/gh-pr-reviewer/AGENT.md
@@ -2,6 +2,7 @@
 name: gh-pr-reviewer
 description: Fetches comprehensive GitHub PR data for code review including complete diff, all files, all reviews, and all CI checks. Optimized for review command.
 allowed-tools: ["Bash"]
+color: indigo
 ---
 
 # GitHub PR Reviewer Subagent

--- a/schovi/agents/jira-analyzer/AGENT.md
+++ b/schovi/agents/jira-analyzer/AGENT.md
@@ -2,6 +2,7 @@
 name: jira-analyzer
 description: Fetches and summarizes Jira issues without polluting parent context. Extracts only essential information for problem analysis.
 allowed-tools: ["mcp__jira__*"]
+color: blue
 ---
 
 # Jira Issue Analyzer Subagent

--- a/schovi/agents/research-executor/AGENT.md
+++ b/schovi/agents/research-executor/AGENT.md
@@ -1,5 +1,6 @@
 ---
 name: research-executor
+color: teal
 allowed-tools: ["Read", "Task", "Grep", "Glob"]
 ---
 

--- a/schovi/agents/spec-generator/AGENT.md
+++ b/schovi/agents/spec-generator/AGENT.md
@@ -2,6 +2,7 @@
 name: spec-generator
 description: Generates actionable implementation specifications from analysis without polluting parent context. Transforms exploratory analysis into structured, implementable specs.
 allowed-tools: ["Read"]
+color: cyan
 ---
 
 # Specification Generator Subagent


### PR DESCRIPTION
Added unique color property to each agent definition to enable visual distinction:
- jira-analyzer: blue
- gh-pr-analyzer: purple
- gh-pr-reviewer: indigo
- gh-issue-analyzer: violet
- datadog-analyzer: orange
- brainstorm-executor: green
- research-executor: teal
- spec-generator: cyan
- debug-executor: red

This allows the UI to visually differentiate agents by their purpose and role.

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>